### PR TITLE
Fixed if-clause to check if one command has failed

### DIFF
--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -73,7 +73,7 @@
       echo "(publish 2 sonar)"
       eval $COMMAND
       RET2=$?
-      if [[ ! $RET1 || ! $RET2 ]]; then
+      if [ $RET1 -ne 0 -o $RET2 -ne 0 ]; then
         exit 1;
       fi
     fi


### PR DESCRIPTION
This should make sure that the build will fail if at least one command (sonar comment or sonar push) has failed